### PR TITLE
Fix %t format for negative timezones, improve tests

### DIFF
--- a/lib/Apache/LogFormat/Compiler.pm6
+++ b/lib/Apache/LogFormat/Compiler.pm6
@@ -141,9 +141,9 @@ use DateTime::Format;
 my sub format-datetime(DateTime $dt) {
     state @abbr = <Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec>;
 
-    return sprintf("%02d/%s/%04d:%02d:%02d:%02d %s%02d%02d",
+    return sprintf("%02d/%s/%04d:%02d:%02d:%02d %+03d%02d",
         $dt.day-of-month, @abbr[$dt.month-1], $dt.year,
-        $dt.hour, $dt.minute, $dt.second, ($dt.offset>0??'+'!!'-'), $dt.offset/3600, $dt.offset%3600);
+        $dt.hour, $dt.minute, $dt.second, $dt.offset/3600, $dt.offset%3600);
 }
 
 our sub safe-value($s) {

--- a/t/00-sanity.t
+++ b/t/00-sanity.t
@@ -2,11 +2,10 @@ use v6;
 use Test;
 use Apache::LogFormat::Compiler;
 
-if ! is(Apache::LogFormat::Compiler::string-value(""), "-", "string-value return '-' when an empty string is passed") {
-    return
-}
-if ! is(Apache::LogFormat::Compiler::string-value(Nil), "-", "string-value return '-' when Nil is passed") {
-    return
-}
+is Apache::LogFormat::Compiler::string-value(""), "-", "string-value return '-' when an empty string is passed"
+    or return;
+
+is Apache::LogFormat::Compiler::string-value(Nil), "-", "string-value return '-' when Nil is passed"
+    or return;
 
 done-testing;

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -2,59 +2,35 @@ use v6;
 use Test;
 use Apache::LogFormat::Compiler;
 
+use lib 't/lib';
+use Apache::LogFormat::TestUtil;
+
 my $f = Apache::LogFormat::Compiler.new();
 my $fmt = $f.compile('%r %t "%{User-agent}i"');
-if ! ok($fmt, "f is valid") {
-    return
-}
+ok $fmt, "f is valid"
+    or return;
 
-if ! isa-ok($fmt, "Apache::LogFormat::Formatter") {
-    return
-}
+isa-ok $fmt, "Apache::LogFormat::Formatter"
+    or return;
 
-my %env = (
-    HTTP_USER_AGENT => "Firefox foo blah\n",
-    REQUEST_METHOD => "GET",
-    REQUEST_URI => "/foo/bar/baz",
-    SERVER_PROTOCOL => "HTTP/1.0",
-);
-my @res = (200, ["Content-Type" => "text/plain"], ["Hello, World".encode('ascii')]);
-my $now = DateTime.now;
+my $got = test_format $fmt;
 
-sub mk_format($tz?) {
-    $fmt.format(%env, @res, 10, Duration.new(1), $tz.defined ?? $now.in-timezone($tz) !! $now);
-}
-
-my $got = mk_format;
-
-if ! ok($got ~~ m!'GET /foo/bar/baz HTTP/1.0'!, "Checking %r") {
-    note $got;
-    return;
-}
-
-sub check_fmt_t($got, :$tz) {
-    my $tag = $tz.defined ?? " - $tz" !! '';
-    ok $got ~~ m!\[\d**2\/<[A..Z]><[a..z]>**2\/\d**4\:\d**2\:\d**2\:\d**2 " " <[\+\-]>\d**4\]!, "checking %t$tag";
-}
-
-# Check with system timezone
-if ! check_fmt_t($got) {
-    note $got;
-    return;
-}
+like $got, rx!'GET /foo/bar/baz HTTP/1.0'!, "checking %r"
+    or return;
 
 # Check with various timezones
-for -21600, 32400, 0 -> $tz {
-    my $got2 = mk_format $tz;
-    if ! check_fmt_t($got2, :$tz) {
-        note $got2;
-        return;
+for Nil, -21600, 32400, 0 -> $tz {
+    my $tag = '';
+    my $got2 = $got;
+    if $tz.defined {
+        $tag = " (tz: $tz)";
+        $got2 = test_format $fmt, :$tz;
     }
+    like $got2, rx/<timefmt>/, "checking %t$tag"
+        or return;
 }
 
-if ! ok($got ~~ /'"Firefox foo blah\\x0a"'/, "line is as expected") {
-    note $got;
-    return;
-}
+like $got, rx/'"Firefox foo blah\\x0a"'/, "line is as expected"
+    or return;
 
 done-testing;

--- a/t/02-predefined.t
+++ b/t/02-predefined.t
@@ -2,27 +2,16 @@ use v6;
 use Test;
 use Apache::LogFormat;
 
+use lib 't/lib';
+use Apache::LogFormat::TestUtil;
+
 my $fmt = Apache::LogFormat.combined();
-if ! isa-ok($fmt, "Apache::LogFormat::Formatter") {
-    return
-}
+isa-ok $fmt, "Apache::LogFormat::Formatter"
+    or return;
 
-my %env = (
-    HTTP_REFERER => "http://doc.perl6.org",
-    HTTP_USER_AGENT => "Firefox foo blah\n",
-    REMOTE_ADDR => "192.168.1.1",
-    REMOTE_USER => "foo",
-    REQUEST_METHOD => "GET",
-    REQUEST_URI => "/foo/bar/baz",
-    SERVER_PROTOCOL => "HTTP/1.0",
-);
-my @res = (200, ["Content-Type" => "text/plain"], ["Hello, World".encode('ascii')]);
-my $t0 = DateTime.now.Instant;
-sleep 1;
-my $now = DateTime.now;
-my $got = $fmt.format(%env, @res, 10, $t0 - $now.Instant, $now);
+my $got = test_format $fmt;
 
-if !ok $got ~~ /^ "192.168.1.1 - foo [" \d**2\/<[A..Z]><[a..z]>**2\/\d**4\:\d**2\:\d**2\:\d**2 " " <[\+\-]>\d**4 '] "GET /foo/bar/baz HTTP/1.0" 200 ' \d+ ' "http://doc.perl6.org" "Firefox foo blah\x0a"' /, "line matches" {
-    note $got;
-}
+like $got, rx/ ^ "192.168.1.1 - foo " <timefmt> ' "GET /foo/bar/baz HTTP/1.0" 200 ' \d+ ' "http://doc.perl6.org" "Firefox foo blah\x0a"' /, "line matches"
+    or return;
+
 done-testing;

--- a/t/03-custom.t
+++ b/t/03-custom.t
@@ -2,36 +2,29 @@ use v6;
 use Test;
 use Apache::LogFormat::Compiler;
 
+use lib 't/lib';
+use Apache::LogFormat::TestUtil;
+
 my $f = Apache::LogFormat::Compiler.new();
 my $fmt = $f.compile('%{Content-Length}i %{Content-Type}i %{Content-Type}o %{Content-Length}o');
-if ! ok($fmt, "f is valid") {
-    return
-}
-if ! isa-ok($fmt, "Apache::LogFormat::Formatter") {
-    return
-}
+ok $fmt, "f is valid"
+    or return;
 
-my %env = (
-    HTTP_USER_AGENT => "Firefox foo blah\n",
-    REQUEST_METHOD => "GET",
-    REQUEST_URI => "/foo/bar/baz",
-    SERVER_PROTOCOL => "HTTP/1.0",
-    CONTENT_TYPE => "application/x-www-form-urlencoded",
-    CONTENT_LENGTH => 7,
-);
+isa-ok $fmt, "Apache::LogFormat::Formatter"
+    or return;
+
 my @res = (
     200,
     ["Content-Type" => "text/plain", "Content-Length" => 2],
     ["OK"],
 );
-my $t0 = DateTime.now.Instant;
-sleep 1;
-my $now = DateTime.now;
-my $got = $fmt.format(%env, @res, 10, $t0 - $now.Instant, $now);
+my %env = (
+    CONTENT_TYPE => "application/x-www-form-urlencoded",
+    CONTENT_LENGTH => 7,
+);
+my $got = test_format $fmt, :%env, :@res;
 
-if ! ok($got ~~ m!'7 application/x-www-form-urlencoded text/plain 2'!, "line is as expected") {
-    note $got;
-    return;
-}
+like $got, rx!'7 application/x-www-form-urlencoded text/plain 2'!, "line is as expected"
+    or return;
 
 done-testing;

--- a/t/04-extra.t
+++ b/t/04-extra.t
@@ -2,29 +2,32 @@ use v6;
 use Test;
 use Apache::LogFormat::Compiler;
 
+use lib 't/lib';
+use Apache::LogFormat::TestUtil;
+
 my $f = Apache::LogFormat::Compiler.new();
 
 my $fmt = $f.compile(
     '%z %{HTTP_X_FORWARDED_FOR|REMOTE_ADDR}Z',
     {'Z' => sub ($block, %env, @res, $length, $reqtime) {
-        is($block, 'HTTP_X_FORWARDED_FOR|REMOTE_ADDR');
-        ok(%env, 'Z - $env');
-        ok(@res, 'Z - @res');
+        is $block, 'HTTP_X_FORWARDED_FOR|REMOTE_ADDR', "Z - block";
+        ok %env, 'Z - $env';
+        ok @res, 'Z - @res';
         return $block;
     }},
     {'z' => sub (%env, @res) {
-        ok(%env, 'z - $env');
-        ok(@res, 'z - @res');
+        ok %env, 'z - $env';
+        ok @res, 'z - @res';
         return %env<HTTP_X_REQ_TEST>;
     }},
 );
-note "ok";
-if ! ok($fmt, "f is valid") {
-    return
-}
-if ! isa-ok($fmt, "Apache::LogFormat::Formatter") {
-    return
-}
+
+pass "alive after compile";
+
+ok $fmt, "f is valid"
+    or return;
+isa-ok $fmt, "Apache::LogFormat::Formatter"
+    or return;
 
 my %env = (
     HTTP_X_REQ_TEST => "foo",
@@ -34,14 +37,9 @@ my @res = (
     ["X-Res-Test" => "bar"],
     ["OK"],
 );
-my $t0 = DateTime.now.Instant;
-sleep 1;
-my $now = DateTime.now;
-my $got = $fmt.format(%env, @res, 10, $t0 - $now.Instant, $now);
+my $got = test_format $fmt, :%env, :@res;
 
-if ! ok($got ~~ m!'foo HTTP_X_FORWARDED_FOR|REMOTE_ADDR'!, "line is as expected") {
-    note $got;
-    return;
-}
+like $got, rx!'foo HTTP_X_FORWARDED_FOR|REMOTE_ADDR'!, "line is as expected"
+    or return;
 
 done-testing;

--- a/t/lib/Apache/LogFormat/TestUtil.pm6
+++ b/t/lib/Apache/LogFormat/TestUtil.pm6
@@ -1,0 +1,28 @@
+use v6;
+unit module Apache::LogFormat::TestUtil;
+
+my token date { \d ** 2 '/' <[A..Z]><[a..z]> ** 2 '/' \d ** 4 }
+my token time { [\d ** 2] ** 3 % ':' }
+my token zone { <[+-]> \d ** 4 }
+my token timefmt is export { '[' <date> ':' <time> ' ' <zone> ']' }
+
+my %def_env = (
+    HTTP_REFERER => "http://doc.perl6.org",
+    HTTP_USER_AGENT => "Firefox foo blah\n",
+    REMOTE_ADDR => "192.168.1.1",
+    REMOTE_USER => "foo",
+    REQUEST_METHOD => "GET",
+    REQUEST_URI => "/foo/bar/baz",
+    SERVER_PROTOCOL => "HTTP/1.0",
+);
+my @def_res = (200, ["Content-Type" => "text/plain"], ["Hello, World".encode('ascii')]);
+
+sub test_format($fmt, :%env is copy, :@res = @def_res, :$now = DateTime.now, :$tz) is export {
+    if %env {
+        %env{ .key } //= .value for %def_env.pairs;
+    }
+    else {
+        %env := %def_env;
+    }
+    $fmt.format(%env, @res, 10, Duration.new(1), $tz.defined ?? $now.in-timezone($tz) !! $now);
+}


### PR DESCRIPTION
If tested in location with negative timezone, the %t format would print like "--600" instead of "-0600".

1. First commit fixes just the bug
2. Second commit adds test case for different time zones
3. Third commit refactors and simplifies test files