### PR TITLE
Enable experimental :pack pragma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@ install:
   - rakudobrew build-panda
   - panda --notests installdeps .
 script:
-  - perl6 -MPanda::Builder -e 'Panda::Builder.build($*CWD)'
-  - PERL6LIB=$PWD/blib/lib prove -e perl6 -vr t/
+  - prove -e 'perl6 -Ilib' -vr t/
 sudo: false

--- a/lib/Apache/LogFormat/Compiler.pm6
+++ b/lib/Apache/LogFormat/Compiler.pm6
@@ -1,4 +1,5 @@
 use v6;
+use experimental :pack;
 use MONKEY-SEE-NO-EVAL;
 
 grammar Apache::LogFormat::Grammar {


### PR DESCRIPTION
'pack' and 'unpack' are experimental features now. Latest rakudo raises runtime error as bellow.

```
% prove -rv -e 'perl6 -Ilib' t/
t/00-sanity.t ......
ok 1 - string-value return '-' when an empty string is passed
ok 2 - string-value return '-' when Nil is passed
1..2
ok
t/01-basic.t .......
ok 1 - f is valid
ok 2 - The object is-a '"Apache::LogFormat::Formatter"'
Use of the 'unpack' method is experimental; please 'use experimental :pack'
  in sub string-value at /home/syohei/src/p6/p6-Apache-LogFormat/lib/Apache/LogFormat/Compiler.pm6 line 166
  in sub  at EVAL_0 line 1
  in method format at /home/syohei/src/p6/p6-Apache-LogFormat/lib/Apache/LogFormat/Formatter.pm6 line 15
  in sub test-format at /home/syohei/src/p6/p6-Apache-LogFormat/t/lib/Apache/LogFormat/TestUtil.pm6 line 27
  in block <unit> at t/01-basic.t line 16

Dubious, test returned 1 (wstat 256, 0x100)
All 2 subtests passed
t/02-predefined.t ..
ok 1 - The object is-a '"Apache::LogFormat::Formatter"'
Use of the 'unpack' method is experimental; please 'use experimental :pack'
  in sub string-value at /home/syohei/src/p6/p6-Apache-LogFormat/lib/Apache/LogFormat/Compiler.pm6 line 166
  in sub  at EVAL_0 line 1
  in method format at /home/syohei/src/p6/p6-Apache-LogFormat/lib/Apache/LogFormat/Formatter.pm6 line 15
  in sub test-format at /home/syohei/src/p6/p6-Apache-LogFormat/t/lib/Apache/LogFormat/TestUtil.pm6 line 27
  in block <unit> at t/02-predefined.t line 12

Dubious, test returned 1 (wstat 256, 0x100)
All 1 subtests passed
t/03-custom.t ......
ok 1 - f is valid
ok 2 - The object is-a '"Apache::LogFormat::Formatter"'
ok 3 - line is as expected
1..3
ok
t/04-extra.t .......
ok 1 - alive after compile
ok 2 - f is valid
ok 3 - The object is-a '"Apache::LogFormat::Formatter"'
ok 4 - z - $env
ok 5 - z - @res
ok 6 - Z - block
ok 7 - Z - $env
ok 8 - Z - @res
ok 9 - line is as expected
1..9
ok

Test Summary Report
-------------------
t/01-basic.t     (Wstat: 256 Tests: 2 Failed: 0)
  Non-zero exit status: 1
  Parse errors: No plan found in TAP output
t/02-predefined.t (Wstat: 256 Tests: 1 Failed: 0)
  Non-zero exit status: 1
  Parse errors: No plan found in TAP output
Files=5, Tests=17,  3 wallclock secs ( 0.02 usr  0.01 sys +  2.82 cusr  0.17 csys =  3.02 CPU)
Result: FAIL
```